### PR TITLE
Allows chat to work over either http or https

### DIFF
--- a/js/libs/libchat.js
+++ b/js/libs/libchat.js
@@ -1,4 +1,4 @@
 $(function(){
    var libchat_efc75c55947db323d4faab725b79307f = { iid:59, key:'fb10446730e271c', width:'240' }
-   $.getScript('http://libanswers.mit.edu/load_chat.php?hash=efc75c55947db323d4faab725b79307f&options=libchat_efc75c55947db323d4faab725b79307f');
+   $.getScript('//mit.libanswers.com/load_chat.php?hash=efc75c55947db323d4faab725b79307f&options=libchat_efc75c55947db323d4faab725b79307f');
 });


### PR DESCRIPTION
This addresses a bug in which some browsers don't allow content to be loaded over http when accessed over https...hopefully without side effects, but it seems fairly safe.
