### PR TITLE
Upgrades libchat button in the meganav to libanswers v2

### DIFF
--- a/inc/nav-main.php
+++ b/inc/nav-main.php
@@ -123,7 +123,7 @@
     <a href="/ask" class="no-underline"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="16.593px" height="16px" viewBox="0 0 16.593 16" enable-background="new 0 0 16.593 16" xml:space="preserve"><path d="M16.593 6.278c0 1.074-0.074 2.148-0.241 3.185 -0.204 1.353-1.722 2.574-3.055 2.722 -1.353 0.131-2.686 0.204-4.02 0.223L5.74 15.833C5.63 15.944 5.481 16 5.334 16c-0.094 0-0.167-0.019-0.241-0.037C4.871 15.87 4.74 15.647 4.74 15.407V12.37c-0.481-0.036-0.963-0.055-1.443-0.111 -1.334-0.148-2.853-1.443-3.074-2.796C0.074 8.426 0 7.352 0 6.296c0-1.092 0.074-2.185 0.223-3.24 0.222-1.352 1.74-2.648 3.074-2.797C4.963 0.093 6.63 0 8.297 0s3.333 0.093 5 0.259c1.333 0.149 2.851 1.445 3.055 2.797C16.519 4.111 16.593 5.204 16.593 6.278"/></svg><span>Ask Us</span></a>
     <div class="links-sub push">
       <div class="wrap-button-chat">
-        <div id='libchat_btn_widget'></div>
+        <div id='libchat_be2c654b63dd43f31c56295ee5d78d88'></div>
       </div>
       <a class="more" href="/ask">More ways to ask us</a>
     </div>

--- a/js/libs/libchat.js
+++ b/js/libs/libchat.js
@@ -1,4 +1,3 @@
 $(function(){
-   var libchat_efc75c55947db323d4faab725b79307f = { iid:59, key:'fb10446730e271c', width:'240' }
-   $.getScript('//mit.libanswers.com/load_chat.php?hash=efc75c55947db323d4faab725b79307f&options=libchat_efc75c55947db323d4faab725b79307f');
+   $.getScript('//v2.libanswers.com/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88');
 });


### PR DESCRIPTION
This is the change needed to switch the chat button over to LibAnswers v2 after the upgrade in mid-July. This has been tested as a hotfix on -dev by @remlee and I, but will need to be re-checked in the usual method on launch day.
